### PR TITLE
Port latest changes from go-nitro till commit `ff84d606` on November 1

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,4 +1,4 @@
-# Porting go-nitro latest commits
+# Development
 
 ## Skipped go-nitro Commits / Features
 

--- a/README.md
+++ b/README.md
@@ -182,3 +182,7 @@ Run relay node using v2 watcher
     ```bash
     clearNodeStorage()
     ```
+
+### Development
+
+* [README](./DEVELOPMENT.md)

--- a/packages/nitro-node/package.json
+++ b/packages/nitro-node/package.json
@@ -61,7 +61,7 @@
     "@libp2p/crypto": "^1.0.4",
     "@libp2p/tcp": "^6.0.0",
     "@multiformats/multiaddr": "^11.1.4",
-    "@statechannels/nitro-protocol": "^2.0.1-alpha.5",
+    "@statechannels/nitro-protocol": "^2.0.1-alpha.6",
     "assert": "^2.0.0",
     "async-mutex": "^0.4.0",
     "debug": "^4.3.4",

--- a/packages/nitro-node/src/node/engine/engine.ts
+++ b/packages/nitro-node/src/node/engine/engine.ts
@@ -719,7 +719,7 @@ export class Engine {
       try {
         chainId = await this.chain.getChainId();
       } catch (err) {
-        return [new EngineEvent({}), new Error(`could not get chain id from chain service: ${err}`)];
+        return [new EngineEvent({}), new WrappedError(`could not get chain id from chain service: ${err}`, err as Error)];
       }
 
       const objectiveId = or.id(myAddress, chainId);
@@ -746,7 +746,7 @@ export class Engine {
               this.store.getConsensusChannel.bind(this.store),
             );
           } catch (err) {
-            return [failedEngineEvent, new Error(`handleAPIEvent: Could not create virtualfund objective for ${or}: ${err}`)];
+            return [failedEngineEvent, new WrappedError(`handleAPIEvent: Could not create virtualfund objective for ${or}: ${err}`, err as Error)];
           }
 
           if (METRICS_ENABLED) {
@@ -784,7 +784,10 @@ export class Engine {
             } catch (err) {
               return [
                 failedEngineEvent,
-                new Error(`handleAPIEvent: Could not create virtualdefund objective for ${JSONbigNative.stringify(request)}: ${err}`),
+                new WrappedError(
+                  `handleAPIEvent: Could not create virtualdefund objective for ${JSONbigNative.stringify(request)}: ${err}`,
+                  err as Error,
+                ),
               ];
             }
           }
@@ -806,7 +809,10 @@ export class Engine {
           } catch (err) {
             return [
               failedEngineEvent,
-              new Error(`handleAPIEvent: Could not create virtualdefund objective for ${JSONbigNative.stringify(request)}: ${err}`),
+              new WrappedError(
+                `handleAPIEvent: Could not create virtualdefund objective for ${JSONbigNative.stringify(request)}: ${err}`,
+                err as Error,
+              ),
             ];
           }
 
@@ -831,7 +837,7 @@ export class Engine {
           } catch (err) {
             return [
               failedEngineEvent,
-              new Error(`handleAPIEvent: Could not create directfund objective for ${JSONbigNative.stringify(or)}: ${err}`),
+              new WrappedError(`handleAPIEvent: Could not create directfund objective for ${JSONbigNative.stringify(or)}: ${err}`, err as Error),
             ];
           }
 
@@ -850,7 +856,10 @@ export class Engine {
           } catch (err) {
             return [
               failedEngineEvent,
-              new Error(`handleAPIEvent: Could not create directdefund objective for ${JSONbigNative.stringify(request)}: ${err}`),
+              new WrappedError(
+                `handleAPIEvent: Could not create directdefund objective for ${JSONbigNative.stringify(request)}: ${err}`,
+                err as Error,
+              ),
             ];
           }
 
@@ -863,7 +872,7 @@ export class Engine {
           } catch (err) {
             return [
               failedEngineEvent,
-              new Error(`handleAPIEvent: Could not destroy consensus channel for ${JSONbigNative.stringify(request)}: ${err}`),
+              new WrappedError(`handleAPIEvent: Could not destroy consensus channel for ${JSONbigNative.stringify(request)}: ${err}`, err as Error),
             ];
           }
 

--- a/packages/nitro-util/DEVELOPMENT.md
+++ b/packages/nitro-util/DEVELOPMENT.md
@@ -1,0 +1,28 @@
+# Development
+
+## Generate contract bindings
+
+* Clone the go-nitro repo (<https://github.com/statechannels/go-nitro>) and run `yarn` in root of repo.
+
+* Move to `go-nitro/packages/nitro-protocol/` and run `yarn hardhat compile` to compile the contract
+
+  ```bash
+  $ yarn hardhat compile
+  Generating typings for: 43 artifacts in dir: typechain-types for target: ethers-v5
+  Successfully generated 67 typings!
+  Compiled 42 Solidity files successfully
+  ```
+
+* Copy files `ConsensusApp.json` `NitroAdjudicator.json` `VirtualPaymentApp.json` from go-nitro `packages/nitro-protocol/artifacts` to ts-nitro `packages/nitro-util/contracts`
+
+* In ts-nitro `packages/nitro-util` run `yarn generate-bindings` to generate the contract bindings
+
+  ```bash
+  $ yarn generate-bindings
+
+  yarn run v1.22.19
+  $ ./scripts/generate-bindings.sh
+  $ /ts-nitro/node_modules/.bin/typechain --target ethers-v5 --out-dir ./src/contract-bindings ./contracts/NitroAdjudicator.json ./contracts/ConsensusApp.json ./contracts/VirtualPaymentApp.json ./contracts/Token.json
+  Successfully generated 11 typings!
+  Done in 1.27s.
+  ```

--- a/packages/nitro-util/README.md
+++ b/packages/nitro-util/README.md
@@ -1,4 +1,6 @@
-# Generate contract bindings
+# nitro-util
+
+## Generate contract bindings
 
 * Clone the go-nitro repo (<https://github.com/statechannels/go-nitro>) and run `yarn` in root of repo.
 

--- a/packages/nitro-util/README.md
+++ b/packages/nitro-util/README.md
@@ -1,0 +1,26 @@
+# Generate contract bindings
+
+* Clone the go-nitro repo (<https://github.com/statechannels/go-nitro>) and run `yarn` in root of repo.
+
+* Move to `go-nitro/packages/nitro-protocol/` and run `yarn hardhat compile` to compile the contract
+
+  ```bash
+  $ yarn hardhat compile
+  Generating typings for: 43 artifacts in dir: typechain-types for target: ethers-v5
+  Successfully generated 67 typings!
+  Compiled 42 Solidity files successfully
+  ```
+
+* Copy files `ConsensusApp.json` `NitroAdjudicator.json` `VirtualPaymentApp.json` from go-nitro `packages/nitro-protocol/artifacts` to ts-nitro `packages/nitro-util/contracts`
+
+* In ts-nitro `packages/nitro-util` run `yarn generate-bindings` to generate the contract bindings
+
+  ```bash
+  $ yarn generate-bindings
+
+  yarn run v1.22.19
+  $ ./scripts/generate-bindings.sh
+  $ /ts-nitro/node_modules/.bin/typechain --target ethers-v5 --out-dir ./src/contract-bindings ./contracts/NitroAdjudicator.json ./contracts/ConsensusApp.json ./contracts/VirtualPaymentApp.json ./contracts/Token.json
+  Successfully generated 11 typings!
+  Done in 1.27s.
+  ```

--- a/packages/nitro-util/README.md
+++ b/packages/nitro-util/README.md
@@ -1,28 +1,5 @@
 # nitro-util
 
-## Generate contract bindings
+## Development
 
-* Clone the go-nitro repo (<https://github.com/statechannels/go-nitro>) and run `yarn` in root of repo.
-
-* Move to `go-nitro/packages/nitro-protocol/` and run `yarn hardhat compile` to compile the contract
-
-  ```bash
-  $ yarn hardhat compile
-  Generating typings for: 43 artifacts in dir: typechain-types for target: ethers-v5
-  Successfully generated 67 typings!
-  Compiled 42 Solidity files successfully
-  ```
-
-* Copy files `ConsensusApp.json` `NitroAdjudicator.json` `VirtualPaymentApp.json` from go-nitro `packages/nitro-protocol/artifacts` to ts-nitro `packages/nitro-util/contracts`
-
-* In ts-nitro `packages/nitro-util` run `yarn generate-bindings` to generate the contract bindings
-
-  ```bash
-  $ yarn generate-bindings
-
-  yarn run v1.22.19
-  $ ./scripts/generate-bindings.sh
-  $ /ts-nitro/node_modules/.bin/typechain --target ethers-v5 --out-dir ./src/contract-bindings ./contracts/NitroAdjudicator.json ./contracts/ConsensusApp.json ./contracts/VirtualPaymentApp.json ./contracts/Token.json
-  Successfully generated 11 typings!
-  Done in 1.27s.
-  ```
+* [README](./DEVELOPMENT.md)

--- a/packages/nitro-util/contracts/NitroAdjudicator.json
+++ b/packages/nitro-util/contracts/NitroAdjudicator.json
@@ -300,6 +300,25 @@
         {
           "indexed": false,
           "internalType": "uint48",
+          "name": "newTurnNumRecord",
+          "type": "uint48"
+        }
+      ],
+      "name": "Checkpointed",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "channelId",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint48",
           "name": "finalizesAt",
           "type": "uint48"
         }

--- a/packages/nitro-util/package.json
+++ b/packages/nitro-util/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@cerc-io/ts-channel": "1.0.3-ts-nitro-0.1.1",
-    "@statechannels/nitro-protocol": "^2.0.1-alpha.5",
+    "@statechannels/nitro-protocol": "^2.0.1-alpha.6",
     "assert": "^2.0.0",
     "debug": "^4.3.4",
     "ethers": "^5.7.2",

--- a/packages/nitro-util/src/contract-bindings/NitroAdjudicator.ts
+++ b/packages/nitro-util/src/contract-bindings/NitroAdjudicator.ts
@@ -302,6 +302,7 @@ export interface NitroAdjudicatorInterface extends utils.Interface {
     "AllocationUpdated(bytes32,uint256,uint256,uint256)": EventFragment;
     "ChallengeCleared(bytes32,uint48)": EventFragment;
     "ChallengeRegistered(bytes32,uint48,tuple[],tuple)": EventFragment;
+    "Checkpointed(bytes32,uint48)": EventFragment;
     "Concluded(bytes32,uint48)": EventFragment;
     "Deposited(bytes32,address,uint256)": EventFragment;
     "Reclaimed(bytes32,uint256)": EventFragment;
@@ -310,6 +311,7 @@ export interface NitroAdjudicatorInterface extends utils.Interface {
   getEvent(nameOrSignatureOrTopic: "AllocationUpdated"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "ChallengeCleared"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "ChallengeRegistered"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "Checkpointed"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "Concluded"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "Deposited"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "Reclaimed"): EventFragment;
@@ -359,6 +361,17 @@ export type ChallengeRegisteredEvent = TypedEvent<
 
 export type ChallengeRegisteredEventFilter =
   TypedEventFilter<ChallengeRegisteredEvent>;
+
+export interface CheckpointedEventObject {
+  channelId: string;
+  newTurnNumRecord: number;
+}
+export type CheckpointedEvent = TypedEvent<
+  [string, number],
+  CheckpointedEventObject
+>;
+
+export type CheckpointedEventFilter = TypedEventFilter<CheckpointedEvent>;
 
 export interface ConcludedEventObject {
   channelId: string;
@@ -780,6 +793,15 @@ export interface NitroAdjudicator extends BaseContract {
       proof?: null,
       candidate?: null
     ): ChallengeRegisteredEventFilter;
+
+    "Checkpointed(bytes32,uint48)"(
+      channelId?: BytesLike | null,
+      newTurnNumRecord?: null
+    ): CheckpointedEventFilter;
+    Checkpointed(
+      channelId?: BytesLike | null,
+      newTurnNumRecord?: null
+    ): CheckpointedEventFilter;
 
     "Concluded(bytes32,uint48)"(
       channelId?: BytesLike | null,

--- a/packages/nitro-util/src/contract-bindings/factories/NitroAdjudicator__factory.ts
+++ b/packages/nitro-util/src/contract-bindings/factories/NitroAdjudicator__factory.ts
@@ -307,6 +307,25 @@ const _abi = [
       {
         indexed: false,
         internalType: "uint48",
+        name: "newTurnNumRecord",
+        type: "uint48",
+      },
+    ],
+    name: "Checkpointed",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "channelId",
+        type: "bytes32",
+      },
+      {
+        indexed: false,
+        internalType: "uint48",
         name: "finalizesAt",
         type: "uint48",
       },

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -279,8 +279,6 @@ const main = async () => {
     await new Promise<void>((resolve) => { setTimeout(() => resolve(), 1000); });
 
     await nitro.close();
-
-    process.exit(0);
   }
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3949,10 +3949,10 @@
     ethers "^5.1.4"
     lodash "^4.17.21"
 
-"@statechannels/nitro-protocol@^2.0.1-alpha.5":
-  version "2.0.1-alpha.5"
-  resolved "https://registry.yarnpkg.com/@statechannels/nitro-protocol/-/nitro-protocol-2.0.1-alpha.5.tgz#3aa09dacf6780a47ff415de23123f9aafe2534ec"
-  integrity sha512-CT32i5ZlZ0Jz8mAOmywALCnS/+Cl7ntrRlJr2r3jGBkkzNBWxHWR4qXg6HTUh7xxm5tY/g/TSmsGH8/z54K/Sw==
+"@statechannels/nitro-protocol@^2.0.1-alpha.6":
+  version "2.0.1-alpha.6"
+  resolved "https://registry.yarnpkg.com/@statechannels/nitro-protocol/-/nitro-protocol-2.0.1-alpha.6.tgz#1bb59365eb78489eef2dfa73733bc1cad9890685"
+  integrity sha512-VehCgq3AOVTGCvGGIoF23YyQX+x1IbLzByFWbqPovucsm9vW0udR7r8Okw9hC0ZHanHOjQH5KxJL6aKUnrXinw==
   dependencies:
     "@openzeppelin/contracts" "^4.7.3"
     "@statechannels/exit-format" "^0.2.0"


### PR DESCRIPTION
Part of [Port over latest changes from go-nitro](https://www.notion.so/Port-over-latest-changes-from-go-nitro-9b161dbbda2a4caa9bfd4ecd8af493f0)
- Use `@statechannels/nitro-protocol` version `2.0.1-alpha.6` and generate contract bindings
- Add steps in README to generate contract bindings
- Use wrapped error in handle objective request
- Remove immediate termination in wait flag of the server CLI