### PR TITLE
Add methods to register listeners for ledger and payment updates 

### DIFF
--- a/packages/nitro-node/src/node/node.ts
+++ b/packages/nitro-node/src/node/node.ts
@@ -339,4 +339,24 @@ export class Node {
   sentVouchers(): ReadChannel<Voucher> {
     return this.engine.sentVouchers;
   }
+
+  // LedgerUpdates returns a chan that receives ledger channel info whenever that ledger channel is updated. Not suitable for multiple subscribers.
+  ledgerUpdates() {
+    return this.channelNotifier!.registerForAllLedgerUpdates();
+  }
+
+  // PaymentUpdates returns a chan that receives payment channel info whenever that payment channel is updated. Not suitable fo multiple subscribers.
+  paymentUpdates() {
+    return this.channelNotifier!.registerForAllPaymentUpdates();
+  }
+
+  // LedgerUpdatedChan returns a chan that receives a ledger channel info whenever the ledger with given id is updated
+  ledgerUpdatedChan(ledgerId: Destination) {
+    return this.channelNotifier!.registerForLedgerUpdates(ledgerId);
+  }
+
+  // PaymentChannelUpdatedChan returns a chan that receives a payment channel info whenever the payment channel with given id is updated
+  paymentChannelUpdatedChan(ledgerId: Destination) {
+    return this.channelNotifier!.registerForPaymentChannelUpdates(ledgerId);
+  }
 }

--- a/packages/nitro-node/src/node/notifier/channel-notifier.ts
+++ b/packages/nitro-node/src/node/notifier/channel-notifier.ts
@@ -5,6 +5,7 @@ import { Store } from '../engine/store/store';
 import { PaymentChannelListeners, LedgerChannelListeners } from './listeners';
 import { SafeSyncMap } from '../../internal/safesync/safesync';
 import { LedgerChannelInfo, PaymentChannelInfo } from '../query/types';
+import { Destination } from '../../types/destination';
 
 const ALL_NOTIFICATIONS = 'all';
 
@@ -35,6 +36,30 @@ export class ChannelNotifier {
       store,
       vm,
     });
+  }
+
+  // RegisterForAllLedgerUpdates returns a buffered channel that will receive updates for all ledger channels.
+  registerForAllLedgerUpdates() {
+    const [li] = this.ledgerListeners!.loadOrStore(ALL_NOTIFICATIONS, LedgerChannelListeners.newLedgerChannelListeners());
+    return li.getOrCreateListener();
+  }
+
+  // RegisterForLedgerUpdates returns a buffered channel that will receive updates or a specific ledger channel.
+  registerForLedgerUpdates(cId: Destination) {
+    const [li] = this.ledgerListeners!.loadOrStore(cId.string(), LedgerChannelListeners.newLedgerChannelListeners());
+    return li.createNewListener();
+  }
+
+  // RegisterForAllPaymentUpdates returns a buffered channel that will receive updates for all payment channels.
+  registerForAllPaymentUpdates() {
+    const [li] = this.paymentListeners!.loadOrStore(ALL_NOTIFICATIONS, PaymentChannelListeners.newPaymentChannelListeners());
+    return li.getOrCreateListener();
+  }
+
+  // RegisterForPaymentChannelUpdates returns a buffered channel that will receive updates or a specific payment channel.
+  registerForPaymentChannelUpdates(cId: Destination) {
+    const [li] = this.paymentListeners!.loadOrStore(cId.string(), PaymentChannelListeners.newPaymentChannelListeners());
+    return li.createNewListener();
   }
 
   // NotifyLedgerUpdated notifies all listeners of a ledger channel update.

--- a/packages/nitro-node/src/utils/nitro.ts
+++ b/packages/nitro-node/src/utils/nitro.ts
@@ -3,13 +3,14 @@ import { providers } from 'ethers';
 
 // @ts-expect-error
 import type { Peer } from '@cerc-io/peer';
-import { NitroSigner, DEFAULT_ASSET } from '@cerc-io/nitro-util';
+import { NitroSigner, DEFAULT_ASSET, Context } from '@cerc-io/nitro-util';
+import Channel from '@cerc-io/ts-channel';
 
 import { Node } from '../node/node';
 import { P2PMessageService } from '../node/engine/messageservice/p2p-message-service/service';
 import { Store } from '../node/engine/store/store';
 import { Destination } from '../types/destination';
-import { LedgerChannelInfo, PaymentChannelInfo } from '../node/query/types';
+import { ChannelStatus, LedgerChannelInfo, PaymentChannelInfo } from '../node/query/types';
 
 import { createOutcome } from './helpers';
 import { ChainService } from '../node/engine/chainservice/chainservice';
@@ -225,6 +226,97 @@ export class Nitro {
   async getPaymentChannelsByLedger(ledgerChannel: string): Promise<PaymentChannelInfo[]> {
     const ledgerChannelId = new Destination(ledgerChannel);
     return this.node.getPaymentChannelsByLedger(ledgerChannelId);
+  }
+
+  async waitForPaymentChannelStatus(
+    channelId: string,
+    status: ChannelStatus,
+    ctx: Context,
+  ) {
+    const paymentUpdatesChannel = this.node.paymentUpdates();
+
+    while (true) {
+      /* eslint-disable default-case */
+      /* eslint-disable no-await-in-loop */
+      switch (await Channel.select([
+        paymentUpdatesChannel.shift(),
+        ctx.done.shift(),
+      ])) {
+        case paymentUpdatesChannel: {
+          const paymentInfo = paymentUpdatesChannel.value();
+          if (paymentInfo.iD.string() === channelId && paymentInfo.status === status) {
+            return;
+          }
+          break;
+        }
+
+        case ctx.done: {
+          return;
+        }
+      }
+    }
+  }
+
+  async waitForLedgerChannelStatus(
+    channelId: string,
+    status: ChannelStatus,
+    ctx: Context,
+  ) {
+    const ledgerUpdatesChannel = this.node.ledgerUpdates();
+
+    while (true) {
+      /* eslint-disable default-case */
+      /* eslint-disable no-await-in-loop */
+      switch (await Channel.select([
+        ledgerUpdatesChannel.shift(),
+        ctx.done.shift(),
+      ])) {
+        case ledgerUpdatesChannel: {
+          const ledgerInfo = ledgerUpdatesChannel.value();
+          if (ledgerInfo.iD.string() === channelId && ledgerInfo.status === status) {
+            return;
+          }
+          break;
+        }
+
+        case ctx.done: {
+          return;
+        }
+      }
+    }
+  }
+
+  async onPaymentChannelUpdated(
+    channelId: string,
+    callback: (info: PaymentChannelInfo) => void,
+    ctx: Context,
+  ) {
+    const wrapperFn = (info: PaymentChannelInfo) => {
+      if (info.iD.string().toLowerCase() === channelId.toLowerCase()) {
+        callback(info);
+      }
+    };
+
+    const paymentUpdatesChannel = this.node.paymentUpdates();
+
+    while (true) {
+      /* eslint-disable default-case */
+      /* eslint-disable no-await-in-loop */
+      switch (await Channel.select([
+        paymentUpdatesChannel.shift(),
+        ctx.done.shift(),
+      ])) {
+        case paymentUpdatesChannel: {
+          const paymentInfo = paymentUpdatesChannel.value();
+          wrapperFn(paymentInfo);
+          break;
+        }
+
+        case ctx.done: {
+          return;
+        }
+      }
+    }
   }
 
   async close() {

--- a/packages/nitro-node/src/utils/nitro.ts
+++ b/packages/nitro-node/src/utils/nitro.ts
@@ -233,7 +233,7 @@ export class Nitro {
     status: ChannelStatus,
     ctx: Context,
   ) {
-    const paymentUpdatesChannel = this.node.paymentUpdates();
+    const paymentUpdatesChannel = await this.node.paymentUpdates();
 
     while (true) {
       /* eslint-disable default-case */
@@ -262,7 +262,7 @@ export class Nitro {
     status: ChannelStatus,
     ctx: Context,
   ) {
-    const ledgerUpdatesChannel = this.node.ledgerUpdates();
+    const ledgerUpdatesChannel = await this.node.ledgerUpdates();
 
     while (true) {
       /* eslint-disable default-case */
@@ -297,7 +297,7 @@ export class Nitro {
       }
     };
 
-    const paymentUpdatesChannel = this.node.paymentUpdates();
+    const paymentUpdatesChannel = await this.node.paymentUpdates();
 
     while (true) {
       /* eslint-disable default-case */


### PR DESCRIPTION
Part of [Port over latest changes from go-nitro](https://www.notion.so/Port-over-latest-changes-from-go-nitro-9b161dbbda2a4caa9bfd4ecd8af493f0)
- Implement methods `waitForPaymentChannelStatus`, `waitForLedgerChannelStatus` and `onPaymentChannelUpdated` in nitro client